### PR TITLE
An example for how to add compat tests for when 7.x tests are not sufficient.

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.delete_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.delete_watch.json
@@ -1,0 +1,33 @@
+{
+  "xpack-watcher.delete_watch":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html",
+      "description":"Removes a watch from Watcher."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/watcher/watch/{id}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"Watch ID"
+            }
+          },
+          "deprecated" : {
+            "version" : "7.0.0",
+            "description" : "all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.get_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.get_watch.json
@@ -1,0 +1,34 @@
+{
+  "xpack-watcher.get_watch":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html",
+      "description":"Retrieves a watch by its ID."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/watcher/watch/{id}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"Watch ID"
+            }
+          },
+          "deprecated": {
+            "version": "7.0.0",
+            "description": "all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{}
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.put_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.put_watch.json
@@ -1,0 +1,61 @@
+{
+  "xpack-watcher.put_watch": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html",
+      "description": "Creates a new watch, or updates an existing one."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": [
+        "application/vnd.elasticsearch+json;compatible-with=7"
+      ],
+      "content-type": [
+        "application/vnd.elasticsearch+json;compatible-with=7"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_xpack/watcher/watch/{id}",
+          "methods": [
+            "PUT",
+            "POST"
+          ],
+          "parts": {
+            "id": {
+              "type": "string",
+              "description": "Watch ID"
+            }
+          },
+          "deprecated": {
+            "version": "7.0.0",
+            "description": "all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params": {
+      "active": {
+        "type": "boolean",
+        "description": "Specify whether the watch is in/active by default"
+      },
+      "version": {
+        "type": "number",
+        "description": "Explicit version number for concurrency control"
+      },
+      "if_seq_no": {
+        "type": "number",
+        "description": "only update the watch if the last operation that has changed the watch has the specified sequence number"
+      },
+      "if_primary_term": {
+        "type": "number",
+        "description": "only update the watch if the last operation that has changed the watch has the specified primary term"
+      }
+    },
+    "body": {
+      "description": "The watch",
+      "required": false
+    }
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/10_basic_compat.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/10_basic_compat.yml
@@ -1,0 +1,79 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+---
+teardown:
+  - skip:
+      features:
+        - warnings
+        - headers
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
+      xpack-watcher.delete_watch:
+        id: "my_watch"
+        ignore: 404
+
+---
+"Test put, get, and delete watch with 7.x compatibilty":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}] is deprecated! Use [POST /_watcher/watch/{id}] instead."
+        - "[PUT /_xpack/watcher/watch/{id}] is deprecated! Use [PUT /_watcher/watch/{id}] instead."
+      xpack-watcher.put_watch:
+        id: "my_watch"
+        body:  >
+          {
+            "trigger": {
+              "schedule": {
+                "hourly": {
+                  "minute": [ 0, 5 ]
+                  }
+                }
+            },
+            "input": {
+              "simple": {
+                "payload": {
+                  "send": "yes"
+                }
+              }
+            },
+            "condition": {
+              "always": {}
+            },
+            "actions": {
+                "test_index": {
+                  "index": {
+                    "index": "test"
+                  }
+                }
+              }
+            }
+  - match: { _id: "my_watch" }
+  - match: { created: true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
+      xpack-watcher.get_watch:
+        id: "my_watch"
+  - match: { found : true}
+  - match: { _id: "my_watch" }
+  - is_true:  watch
+  - is_false: watch.status


### PR DESCRIPTION
see it in action:
```
./gradlew ':x-pack:plugin:watcher:qa:rest:yamlRestCompatTest' --tests "org.elasticsearch.smoketest.WatcherYamlRestIT" -Dtests.method="test {p0=v7compat/10_basic_compat/Test put, get, and delete watch with 7.x compatibilty}" --info
```