### PR TITLE
Adds a new index time summary

### DIFF
--- a/ingest_report.py
+++ b/ingest_report.py
@@ -78,9 +78,9 @@ def total(data):
     df["time_in_nanos"] = ((df["ingest_time_in_millis"] * 1000000) / (df["count"] + 1)).apply(np.ceil).astype(np.int64)
 
     if t_index_time_in_millis == 0:
-        df["ingesting time %"] = "N/A"
+        df["ingest_time_%"] = "N/A"
     else:
-        df["ingesting time %"] = 100 * t_ingest_time_in_millis / (t_ingest_time_in_millis + t_index_time_in_millis)
+        df["ingest_time_%"] = 100 * t_ingest_time_in_millis / (t_ingest_time_in_millis + t_index_time_in_millis)
         df["index_time_in_millis"] = t_index_time_in_millis
 
     return df

--- a/ingest_report.py
+++ b/ingest_report.py
@@ -14,6 +14,26 @@ def title(str):
 def nanos_per(millis, count):
     return math.ceil(millis * 1000000 / count)
 
+def index_and_ingest_time_summary(data):
+    total_index_time = 0
+    total_ingest_time = 0
+    nodes = data["nodes"]
+    for node in nodes: 
+        if "indices" not in nodes[node]:
+            return "N/A (A full _nodes/stats report is needed)"
+
+        total_index_time = total_index_time + nodes[node]["indices"]["indexing"]["index_time_in_millis"]
+        total_ingest_time = total_ingest_time + nodes[node]["ingest"]["total"]["time_in_millis"]
+
+    arr = np.zeros((1, 3), dtype=np.int64)
+    df = pd.DataFrame(arr, index=["total"], columns=["ingesting %", "total_index_time_millis", "total_ingest_time_millis"])
+    
+    df["total_index_time_millis"] = total_index_time,
+    df["total_ingest_time_millis"] = total_ingest_time,
+    df["ingesting %"] = 100 * total_ingest_time / (total_ingest_time + total_index_time)
+
+    return df
+
 def _ingests(data):
     ingests = []
     for n in data["nodes"].keys():
@@ -127,6 +147,10 @@ def command(full, diagnostic_directory):
 
     print(title("Ingest Summary:"))
     print(t)
+    print()
+
+    print(title("Index & Ingest Summary:"))
+    print(index_and_ingest_time_summary(data))
     print()
 
     print(title("Pipeline Summary:"))

--- a/ingest_report.py
+++ b/ingest_report.py
@@ -65,7 +65,7 @@ def total(data):
 
     t_index_time_in_millis = 0
     nodes = data["nodes"]
-    for node in nodes: 
+    for node in nodes:
         if "indices" not in nodes[node]:
             break
 
@@ -125,7 +125,7 @@ def validate(diagnostic_directory):
 
 @click.command()
 @click.argument("diagnostic_directory")
-@click.option('--full', is_flag=True, default = False)
+@click.option('--full', is_flag=True, default=False)
 def command(full, diagnostic_directory):
     validate(diagnostic_directory)
 

--- a/ingest_report.py
+++ b/ingest_report.py
@@ -74,8 +74,8 @@ def total(data):
     arr[0, 0] = t_count
     arr[0, 1] = t_ingest_time_in_millis
 
-    df = pd.DataFrame(arr, index=["total"], columns=["count", "ingest_time_in_millis"])
-    df["time_in_nanos"] = ((df["ingest_time_in_millis"] * 1000000) / (df["count"] + 1)).apply(np.ceil).astype(np.int64)
+    df = pd.DataFrame(arr, index=["total"], columns=["count", "time_in_millis"])
+    df["time_in_nanos"] = ((df["time_in_millis"] * 1000000) / (df["count"] + 1)).apply(np.ceil).astype(np.int64)
 
     if t_index_time_in_millis == 0:
         df["ingest_time_%"] = "N/A"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click==8.1.3
 numpy==1.23.4
 pandas==1.5.1
 Pygments==2.13.0


### PR DESCRIPTION
Full nodes stats:

```
$ ./ingest_report.py test/diagnostic-rally-date-caching
Ingest & Index Summary:
=======================
          count  ingest_time_in_millis  time_in_nanos  ingesting time %  index_time_in_millis
total  86804123                5520615          63599             22.4%              19129189
(...)
```

Missing the index section of nodes stats
```
./ingest_report.py test/diagnostic-rally-base-1
Ingest & Index Summary:
=======================
          count  ingest_time_in_millis  time_in_nanos ingesting time %
total  90796926                3854166          42449              N/A

(...)
```


Also, I've added an option to display the full summary (--full) because it's misleading at first sight for some use cases (yesterday I was comparing incorrect results for more than 10 minutes until I noticed the results were not the same for the `logging` use-case due to the report was showing only 5 elements)